### PR TITLE
Refactor filter logic to separate Domain and Type filters

### DIFF
--- a/index.html
+++ b/index.html
@@ -14,32 +14,34 @@
 </script>
   <body>
     <section class="text-center">
-  <p class="filter-label">Domain:</p>
-  <button id="Health" class="btnFilter"> Health </button>
-  <button id="Earth" class="btnFilter"> Earth </button>
-  <button id="Engineering" class="btnFilter"> Engineering and Physics </button>
-  <button id="Humanities" class="btnFilter">
-    Humanities
-  </button>
-  <button id="Computer" class="btnFilter">
-    Computer Science
-  </button>
-<p style="margin-top: 1px; margin-bottom: 1px;"></p>
-  <p class="filter-label">Type:</p>
-  <button id="Program" class="btnFilter">
-    Programs and Partnerships
-  </button>
-  <button id="Tool" class="btnFilter">
-    Tools and Platforms
-  </button>
-  <button id="Data" class="btnFilter">
-    Datasets
-  </button>
-  <button id="Knowledge" class="btnFilter">
-    Knowledge
-  </button>
-  <button id="all" class="btnFilter all-button mt-4"> All </button>
-</section>
+      <div id="domain-filters">
+        <p class="filter-label">Domain:</p>
+        <button id="Health" class="btnFilter"> Health </button>
+        <button id="Earth" class="btnFilter"> Earth </button>
+        <button id="Engineering" class="btnFilter"> Engineering and Physics </button>
+        <button id="Humanities" class="btnFilter">
+          Humanities
+        </button>
+        <button id="Computer" class="btnFilter">
+          Computer Science
+        </button>
+      </div>
+      <div id="type-filters">
+        <p class="filter-label">Type:</p>
+        <button id="Program" class="btnFilter">
+          Programs and Partnerships
+        </button>
+        <button id="Tool" class="btnFilter">
+          Tools and Platforms
+        </button>
+        <button id="Data" class="btnFilter">
+          Datasets
+        </button>
+        <button id="Knowledge" class="btnFilter">
+          Knowledge
+        </button>
+      </div>
+    </section>
 
     <section
       id="resourcesContainer"

--- a/index.js
+++ b/index.js
@@ -1,104 +1,89 @@
 const resourcesContainer = document.querySelector("#resourcesContainer");
-      const resourceTemplate = document.querySelector("template");
-      const filterButtons = document.querySelectorAll(".btnFilter");
-      const allButton = document.getElementById("all");
+const resourceTemplate = document.querySelector("template");
+const domainFilters = document.querySelectorAll("#domain-filters .btnFilter");
+const typeFilters = document.querySelectorAll("#type-filters .btnFilter");
 
-      // Use a Set to store selected tags for efficient adding and removing
-      let selectedTags = new Set();
+let selectedDomain = null;
+let selectedType = null;
 
-      function renderResources() {
-        clearContainer(resourcesContainer);
+function renderResources() {
+  clearContainer(resourcesContainer);
 
-        let resourcesToDisplay = dataResources;
+  let resourcesToDisplay = dataResources.filter((resourceData) => {
+    const domainMatch = selectedDomain ? resourceData.tags.includes(selectedDomain) : true;
+    const typeMatch = selectedType ? resourceData.tags.includes(selectedType) : true;
+    return domainMatch && typeMatch;
+  });
 
-        // If no tags are selected, show all resources.
-        // Otherwise, filter based on selected tags.
-        if (selectedTags.size > 0) {
-          resourcesToDisplay = dataResources.filter((resourceData) =>
-            // Check if the resource has at least one tag that is in the selectedTags set
-            resourceData.tags.some((tag) => selectedTags.has(tag)),
-          );
-        }
+  resourcesToDisplay.forEach((resourceData) => {
+    const resourceCard = copyTemplateCard(resourceData);
+    resourcesContainer.appendChild(resourceCard);
+  });
+}
 
-        // Iterate through the resources to display and append them to the container
-        resourcesToDisplay.forEach((resourceData) => {
-          const resourceCard = copyTemplateCard(resourceData);
-          resourcesContainer.appendChild(resourceCard);
-        });
-      }
+function clearContainer(container) {
+  container.innerHTML = "";
+}
 
-      function clearContainer(container) {
-        container.innerHTML = "";
-      }
+function copyTemplateCard(resourceData) {
+  const resourceTemplateContent = document.importNode(resourceTemplate.content, true);
+  const card = resourceTemplateContent.querySelector("#resource");
 
-      function copyTemplateCard(resourceData) {
-        const resourceTemplateContent = document.importNode(resourceTemplate.content, true);
-        const card = resourceTemplateContent.querySelector("#resource");
+  const title = card.querySelector("#title");
+  title.innerText = resourceData.title;
+  title.href = resourceData.link;
 
-        // Set Title
-        const title = card.querySelector("#title");
-        title.innerText = resourceData.title;
-        title.href = resourceData.link;
+  const description = card.querySelector("#description");
+  description.innerText = resourceData.description;
 
-        // Set Description
-        const description = card.querySelector("#description");
-        description.innerText = resourceData.description;
+  const tagsContainer = card.querySelector("#tagsContainer");
+  resourceData.tags.forEach((resourceDataTag) => {
+      const individualTag = document.createElement("span");
+      individualTag.style.backgroundColor = "#ceead6";
+      individualTag.style.color = "#000";
+      individualTag.style.borderRadius = "0.5rem";
+      individualTag.style.padding = "0.25rem 0.25rem";
+      individualTag.style.fontSize = "0.5rem";
+      individualTag.style.fontWeight = "500";
+      individualTag.style.display = "inline-block";
+      individualTag.textContent = `#${resourceDataTag}`;
 
-        // Set Tags
-        const tagsContainer = card.querySelector("#tagsContainer");
-        resourceData.tags.forEach((resourceDataTag) => {
-            const individualTag = document.createElement("span");
-            individualTag.style.backgroundColor = "#ceead6"; /* Muted teal */
-            individualTag.style.color = "#000"; /* Black font */
-            individualTag.style.borderRadius = "0.5rem";
-            individualTag.style.padding = "0.25rem 0.25rem";
-            individualTag.style.fontSize = "0.5rem";
-            individualTag.style.fontWeight = "500";
-            individualTag.style.display = "inline-block";
-            individualTag.textContent = `#${resourceDataTag}`; // Use textContent for security
+      tagsContainer.appendChild(individualTag);
+  });
 
-            tagsContainer.appendChild(individualTag);
-        });
+  return card;
+}
 
-        return card;
-      }
-
-      function handleFilterButtonClick() {
+// In a more complex app, we'd use a state management object
+domainFilters.forEach(btn => {
+    btn.addEventListener("click", function() {
         const tag = this.id;
-
-        if (tag === 'all') {
-          // If 'All' is clicked, clear all selected tags and remove 'selected' class
-          selectedTags.clear();
-          filterButtons.forEach(btn => btn.classList.remove('selected'));
-          allButton.classList.add('selected'); // Optionally keep 'All' selected visually
-        } else {
-          // If another tag is clicked
-          allButton.classList.remove('selected'); // Deselect 'All'
-
-          if (selectedTags.has(tag)) {
-            // If the tag is already selected, deselect it
-            selectedTags.delete(tag);
+        if (selectedDomain === tag) {
+            selectedDomain = null;
             this.classList.remove('selected');
-          } else {
-            // If the tag is not selected, select it
-            selectedTags.add(tag);
+        } else {
+            domainFilters.forEach(b => b.classList.remove('selected'));
+            selectedDomain = tag;
             this.classList.add('selected');
-          }
-
-          // If no tags are selected after clicking a tag other than 'all', select 'all'
-          if (selectedTags.size === 0) {
-             allButton.classList.add('selected');
-          }
         }
-
         renderResources();
-      }
+    });
+});
 
-      // Add event listeners to filter buttons
-      filterButtons.forEach(function (btn) {
-        btn.addEventListener("click", handleFilterButtonClick);
-      });
+typeFilters.forEach(btn => {
+    btn.addEventListener("click", function() {
+        const tag = this.id;
+        if (selectedType === tag) {
+            selectedType = null;
+            this.classList.remove('selected');
+        } else {
+            typeFilters.forEach(b => b.classList.remove('selected'));
+            selectedType = tag;
+            this.classList.add('selected');
+        }
+        renderResources();
+    });
+});
 
-      // Initial render with all resources
-      allButton.classList.add('selected'); // Mark 'All' as selected initially
-      renderResources();
+
+renderResources();


### PR DESCRIPTION
This commit refactors the resource filtering functionality.

Key changes:
- The "Domain" and "Type" filters are now treated as separate groups, allowing one selection from each.
- The "All" button has been removed. De-selecting an active filter now reverts to showing all resources for that category.
- The filtering logic is now a logical AND between the selected Domain and Type.
- The HTML has been restructured to group the filters, and the JavaScript has been updated to handle the new interaction model.